### PR TITLE
Use classifiers to specify the license.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,9 @@ setup(name='tavolo',
       description='Collection of deep learning modules and layers for the TensorFlow framework',
       url='https://github.com/eliorc/tavolo',
       author='Elior Cohen',
-      license='MIT',
+      classifiers=[
+          'License :: OSI Approved :: MIT License',
+      ],
       packages=['tavolo'],
       install_requires=[
           'numpy',


### PR DESCRIPTION
Classifiers are a standard way of specifying a license, and make it easy
for automated tools to properly detect the license of the package.

The "license" field should only be used if the license has no
corresponding Trove classifier.